### PR TITLE
chore: replace Discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You can contribute in 2 ways:
   // OPTIONAL: URL to the project's Telegram channel.
   "telegram": "https://telegram.me/switchboardxyz",
   // OPTIONAL: URL to the project's Discord channel invite.
-  "discord": "https://discord.gg/switchboardxyz"
+  "discord": "https://discord.gg/TJAv6ZYvPC"
 }
 ```
 


### PR DESCRIPTION
## Summary
- Replace expired Discord invite link (`discord.gg/switchboardxyz`) with new permanent link (`discord.gg/TJAv6ZYvPC`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)